### PR TITLE
Chunk sharing breakdown

### DIFF
--- a/supporting_tools/analysis-scripts/config_files/chunk_analysis.cfg
+++ b/supporting_tools/analysis-scripts/config_files/chunk_analysis.cfg
@@ -1,0 +1,9 @@
+[OPERATION]
+AnalysisMode="chunk-sharing"
+ResultsDirectory="chunking-analysis-results/"
+
+[CHUNKSHARING]
+HistogramFigureName="chunk-sharing-hist.png"
+
+[CHUNKFREQUENCY]
+HistogramFigureName="chunk-freq-hist.png"

--- a/supporting_tools/analysis-scripts/generate_chunk_frequency_breakdown.py
+++ b/supporting_tools/analysis-scripts/generate_chunk_frequency_breakdown.py
@@ -2,133 +2,80 @@
 
 import sys
 import matplotlib.pyplot as plt
+import configparser
 
-"""
-    Dictionary holding properties of all read chunks. Indexed by chunk_hash from the hash files.
-    Each entry is itself a dictionary holding all the properties of the relevant chunk.
-"""
-CHUNK_PROPERTIES = {}
-NUM_CLIENTS = 0
-FIG_SAVE_PATH = 'chunk_sharing.jpg'
+import hashfilereader
 
+# Hold configuration information
+config_parser = None
 
-def create_chunk_record(chunk_hash: str, chunk_size: int) -> None:
-    global CHUNK_PROPERTIES
-    
-    """
-        Create a dictionary entry for chunk with hash 'chunk_hash' and initialize it.
-        @param chunk_hash: Hash of new chunk
-        @return: Pointer to newly created entry for ease of access
-    """
-
-    CHUNK_PROPERTIES[chunk_hash] = {}
-    
-    new_entry = CHUNK_PROPERTIES[chunk_hash]
-    new_entry['size'] = chunk_size
-    new_entry['clients'] = []
-    new_entry['frequency'] = 0
-
-    return new_entry
-
-
-def read_hash_files(hash_file_paths) -> None:
-    global CHUNK_PROPERTIES, NUM_CLIENTS
-    """
-        Iterate over all specified hash files and calculate chunk ownership counts
-        @param hash_file_paths: List of hash files to read. Function assumes one hash file per client.
-        @return: None
-    """
-
-    NUM_CLIENTS = len(hash_file_paths)
-
-    # Iterate over each hash file
-    for i in range(NUM_CLIENTS):
-        with open(hash_file_paths[i], 'r') as hash_file:
-            for line in hash_file:
-                line_split = line.strip().split(",")
-
-                if(len(line_split)) != 2:
-                    continue
-
-                chunk_hash = line_split[0].strip()
-                chunk_size = int(line_split[1].strip())
-
-                if(chunk_hash not in CHUNK_PROPERTIES.keys()):
-                    # New chunk hash observed
-                    chunk_entry = create_chunk_record(chunk_hash, chunk_size)
-                    chunk_entry['clients'].append(i)
-                    chunk_entry['frequency'] = 1
-                else:
-                    # Update record for existing chunk hash
-                    chunk_entry = CHUNK_PROPERTIES[chunk_hash]
-
-                    # Sanity check to make sure the same hash isn't present with 2 different chunk sizes
-                    if(chunk_entry['size'] != chunk_size):
-                        raise Exception('Chunk ' + str(chunk_hash) + 'has different sizes: ' + str(chunk_size) + "," + str(chunk_entry['size']))
-                    
-                    # New client holding this chunk
-                    if(i not in chunk_entry['clients']):
-                        chunk_entry['clients'].append(i)
-
-                    # New occurence of chunk
-                    chunk_entry['frequency'] += 1
-
-def generate_chunk_histogram_data() -> list:
+def generate_shared_chunk_histogram_data(hash_reader: hashfilereader.HashFileReader) -> list:
     """
         Creates the underlying data for a chunk sharing histogram
-        @param: None
+        @param hash_reader: Instance of hashfilereader.HashFileReader which has properties of all desired chunks stored.
         @return: List containing counts of shared chunks. Each index has the number of chunks shared across <index_value> clients.
                 Eg: Index 1 has the count of chunks owned by only 1 client
                     Index 2 has the count of chunks owned by 2 clients.
     """
-    global CHUNK_PROPERTIES
+
+    chunk_properties = hash_reader.get_chunk_properties()
+    num_hash_files = hash_reader.get_files_read()
 
     # List to hold counts of shared chunks
-    shared_chunk_counts = [0 for i in range(NUM_CLIENTS+1)]
-
+    shared_chunk_counts = [0 for i in range(num_hash_files+1)]
+    # Remove value at first index (always 0 as it represents the chunks shared by 0 clients)
+    shared_chunk_counts.pop(0)
+    
     # Iterate over global dict of records
-    for chunk_hash, chunk_props in CHUNK_PROPERTIES.items():
-        chunk_client_count = len(chunk_props['clients'])
+    for chunk_hash, chunk_props in chunk_properties.items():
+        chunk_client_count = len(chunk_props['files'])
         shared_chunk_counts[chunk_client_count] += 1
 
-    return shared_chunk_counts
+    hist_x = [i+1 for i in range(hash_reader.get_files_read())]
+
+
+    return shared_chunk_counts, hist_x
 
 def plot_histogram(hist_x, hist_y):
     """
         Function to plot histogram along with relevant styling code
     """
     
+    analysis_mode = config_parser['OPERATION']['AnalysisMode']
+    if(analysis_mode == "chunk-sharing"):
+        fig_save_path = config_parser['CHUNKSHARING']['HistogramFigureName']
+    elif(analysis_mode == "chunk-frequency"):
+        fig_save_path = config_parser['CHUNKFREQUENCY']['HistogramFigureName']
+
+
     plt.style.use('ggplot')
     
     plt.bar(hist_x, hist_y)
     plt.xticks(hist_x)
     
     plt.tight_layout()
-    plt.savefig(FIG_SAVE_PATH)
+    plt.savefig(fig_save_path)
 
 
 if(__name__ == "__main__"):
+    # Main driver code to plot histograms
     if(len(sys.argv) < 2):
-        print("Usage: ./generate_chunk_frequency_breakdown.py <client_hash_file_1> [<client_hash_file_2>...]")     
+        print("Usage: ./generate_chunk_frequency_breakdown.py <config_file> <client_hash_file_1> [<client_hash_file_2>...]")     
 
-    client_hash_file_paths = [sys.argv[i] for i in range(1, len(sys.argv))]
+    config_path = sys.argv[1]
+    client_hash_file_paths = [sys.argv[i] for i in range(2, len(sys.argv))]
     
+    config_parser = configparser.ConfigParser()
+    config_parser.read(config_path)
+
+    hash_reader = hashfilereader.HashFileReader()
+
     # Read all input hash files
-    read_hash_files(client_hash_file_paths)
+    hash_reader.read_hash_files(client_hash_file_paths)
 
     # Calculate shared chunk counts
-    hist_y = generate_chunk_histogram_data()
-    # Remove value at first index (always 0 as it represents the chunks shared by 0 clients)
-    hist_y.pop(0)
+    hist_y, hist_x = generate_shared_chunk_histogram_data(hash_reader) 
     
-    hist_x = [i+1 for i in range(NUM_CLIENTS)]
-
     # Plot and save
     plot_histogram(hist_x, hist_y)
     
-
-
-    
-            
-            
-        

--- a/supporting_tools/analysis-scripts/generate_chunk_frequency_breakdown.py
+++ b/supporting_tools/analysis-scripts/generate_chunk_frequency_breakdown.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3.8
+
+import sys
+import matplotlib.pyplot as plt
+
+"""
+    Dictionary holding properties of all read chunks. Indexed by chunk_hash from the hash files.
+    Each entry is itself a dictionary holding all the properties of the relevant chunk.
+"""
+CHUNK_PROPERTIES = {}
+NUM_CLIENTS = 0
+FIG_SAVE_PATH = 'chunk_sharing.jpg'
+
+
+def create_chunk_record(chunk_hash: str, chunk_size: int) -> None:
+    global CHUNK_PROPERTIES
+    
+    """
+        Create a dictionary entry for chunk with hash 'chunk_hash' and initialize it.
+        @param chunk_hash: Hash of new chunk
+        @return: Pointer to newly created entry for ease of access
+    """
+
+    CHUNK_PROPERTIES[chunk_hash] = {}
+    
+    new_entry = CHUNK_PROPERTIES[chunk_hash]
+    new_entry['size'] = chunk_size
+    new_entry['clients'] = []
+    new_entry['frequency'] = 0
+
+    return new_entry
+
+
+def read_hash_files(hash_file_paths) -> None:
+    global CHUNK_PROPERTIES, NUM_CLIENTS
+    """
+        Iterate over all specified hash files and calculate chunk ownership counts
+        @param hash_file_paths: List of hash files to read. Function assumes one hash file per client.
+        @return: None
+    """
+
+    NUM_CLIENTS = len(hash_file_paths)
+
+    # Iterate over each hash file
+    for i in range(NUM_CLIENTS):
+        with open(hash_file_paths[i], 'r') as hash_file:
+            for line in hash_file:
+                line_split = line.strip().split(",")
+
+                if(len(line_split)) != 2:
+                    continue
+
+                chunk_hash = line_split[0].strip()
+                chunk_size = int(line_split[1].strip())
+
+                if(chunk_hash not in CHUNK_PROPERTIES.keys()):
+                    # New chunk hash observed
+                    chunk_entry = create_chunk_record(chunk_hash, chunk_size)
+                    chunk_entry['clients'].append(i)
+                    chunk_entry['frequency'] = 1
+                else:
+                    # Update record for existing chunk hash
+                    chunk_entry = CHUNK_PROPERTIES[chunk_hash]
+
+                    # Sanity check to make sure the same hash isn't present with 2 different chunk sizes
+                    if(chunk_entry['size'] != chunk_size):
+                        raise Exception('Chunk ' + str(chunk_hash) + 'has different sizes: ' + str(chunk_size) + "," + str(chunk_entry['size']))
+                    
+                    # New client holding this chunk
+                    if(i not in chunk_entry['clients']):
+                        chunk_entry['clients'].append(i)
+
+                    # New occurence of chunk
+                    chunk_entry['frequency'] += 1
+
+def generate_chunk_histogram_data() -> list:
+    """
+        Creates the underlying data for a chunk sharing histogram
+        @param: None
+        @return: List containing counts of shared chunks. Each index has the number of chunks shared across <index_value> clients.
+                Eg: Index 1 has the count of chunks owned by only 1 client
+                    Index 2 has the count of chunks owned by 2 clients.
+    """
+    global CHUNK_PROPERTIES
+
+    # List to hold counts of shared chunks
+    shared_chunk_counts = [0 for i in range(NUM_CLIENTS+1)]
+
+    # Iterate over global dict of records
+    for chunk_hash, chunk_props in CHUNK_PROPERTIES.items():
+        chunk_client_count = len(chunk_props['clients'])
+        shared_chunk_counts[chunk_client_count] += 1
+
+    return shared_chunk_counts
+
+def plot_histogram(hist_x, hist_y):
+    """
+        Function to plot histogram along with relevant styling code
+    """
+    
+    plt.style.use('ggplot')
+    
+    plt.bar(hist_x, hist_y)
+    plt.xticks(hist_x)
+    
+    plt.tight_layout()
+    plt.savefig(FIG_SAVE_PATH)
+
+
+if(__name__ == "__main__"):
+    if(len(sys.argv) < 2):
+        print("Usage: ./generate_chunk_frequency_breakdown.py <client_hash_file_1> [<client_hash_file_2>...]")     
+
+    client_hash_file_paths = [sys.argv[i] for i in range(1, len(sys.argv))]
+    
+    # Read all input hash files
+    read_hash_files(client_hash_file_paths)
+
+    # Calculate shared chunk counts
+    hist_y = generate_chunk_histogram_data()
+    # Remove value at first index (always 0 as it represents the chunks shared by 0 clients)
+    hist_y.pop(0)
+    
+    hist_x = [i+1 for i in range(NUM_CLIENTS)]
+
+    # Plot and save
+    plot_histogram(hist_x, hist_y)
+    
+
+
+    
+            
+            
+        

--- a/supporting_tools/analysis-scripts/hashfilereader.py
+++ b/supporting_tools/analysis-scripts/hashfilereader.py
@@ -1,0 +1,98 @@
+class HashFileReader:
+    """
+        Class to read hash files and store chunk properties indexed by chunk hash
+    """
+    def __init__(self) -> None:
+        """
+            Default Constructor
+        """
+
+        # Dictionary holding properties of all read chunks. Indexed by chunk_hash from the hash files.
+            # Each entry is itself a dictionary holding all the properties of the relevant chunk.
+        self.chunk_properties = {}
+        
+        # Number of files read so far
+        self.hash_files_read = 0
+        pass
+
+    def _create_chunk_record(self, chunk_hash: str, chunk_size: int) -> dict:    
+        """
+            Create a dictionary entry for chunk with hash 'chunk_hash' and initialize it.
+            @param chunk_hash: Hash of new chunk
+            @return: Pointer to newly created entry for ease of access
+        """
+
+        self.chunk_properties[chunk_hash] = {}
+        
+        new_entry = self.chunk_properties[chunk_hash]
+        new_entry['size'] = chunk_size
+        new_entry['files'] = []
+        new_entry['frequency'] = 0
+
+        return new_entry
+
+    def get_chunk_properties(self) -> dict:
+        """
+            Return a pointer to stored chunk properties
+        """
+        return self.chunk_properties
+
+    def get_files_read(self) -> int:
+        """
+            Return number of hash files read so far
+        """
+        return self.hash_files_read
+
+    def read_hash_file(self, hash_file_path: str) -> None:
+        """
+            Read a single hash file and store all chunk properties
+            @param hash_file_path: Path to hash file
+            @return: None
+        """
+
+        chunk_properties = self.chunk_properties
+        self.hash_files_read += 1
+
+        with open(hash_file_path, 'r') as hash_file:
+            for line in hash_file:
+                line_split = line.strip().split(",")
+
+                if(len(line_split)) != 2:
+                    continue
+
+                chunk_hash = line_split[0].strip()
+                chunk_size = int(line_split[1].strip())
+
+                if(chunk_hash not in chunk_properties.keys()):
+                    # New chunk hash observed
+                    chunk_entry = self._create_chunk_record(chunk_hash, chunk_size)
+                    chunk_entry['files'].append(self.hash_files_read)
+                    chunk_entry['frequency'] = 1
+                else:
+                    # Update record for existing chunk hash
+                    chunk_entry = chunk_properties[chunk_hash]
+
+                    # Sanity check to make sure the same hash isn't present with 2 different chunk sizes
+                    if(chunk_entry['size'] != chunk_size):
+                        raise Exception('Chunk ' + str(chunk_hash) + 'has different sizes: ' + str(chunk_size) + "," + str(chunk_entry['size']))
+                    
+                    # New client holding this chunk
+                    if(self.hash_files_read not in chunk_entry['clients']):
+                        chunk_entry['files'].append(self.hash_files_read)
+
+                    # New occurence of chunk
+                    chunk_entry['frequency'] += 1
+    
+    def read_hash_files(self, hash_files: list) -> None:
+        """
+            Read all specified hash files and store all chunk properties
+            @param hash_files: List of str containing paths to each hash file
+            @return: None
+        """
+
+        # Iterate over all specified files
+        for file_path in hash_files:
+                self.read_hash_file(file_path)
+
+
+


### PR DESCRIPTION
Raising a new pull request for this. This commit adds supporting python scripts to analyze hash files generated by secure-dedup.

hashfilereader.py - Module containing class and functions to parse hash files
generate_chunk_frequency_breakdown.py - Calculates chunk sharing data and plots a histogram. Uses the ConfigParser module to read a config file (such as the one provided within the commit)
