### PR TITLE
add cstring header to rabin and ae

### DIFF
--- a/dedup/include/chunking/ae_chunking.hpp
+++ b/dedup/include/chunking/ae_chunking.hpp
@@ -7,6 +7,8 @@
 #include "chunking_common.hpp"
 #include "config.hpp"
 
+#include <cstring>
+
 #define DEFAULT_AE_AVG_BLOCK_SIZE 4096
 #define BUFFER_SIZE 65535
 

--- a/dedup/include/chunking/rabins_chunking.hpp
+++ b/dedup/include/chunking/rabins_chunking.hpp
@@ -5,6 +5,9 @@
 #include "config.hpp"
 #include "rabins_hashing.hpp"
 
+#include <cstring>
+
+
 #define DEFAULT_RABINC_WINDOW_SIZE 32
 #define DEFAULT_RABINC_MIN_BLOCK_SIZE 1024
 #define DEFAULT_RABINC_AVG_BLOCK_SIZE 8192


### PR DESCRIPTION
This PR adds cstring header to rabins_chunking.hpp and ae_chunking.hpp for memcopy usage.