### PR TITLE
Factor out read file logic

### DIFF
--- a/dedup/include/chunking/ae_chunking.hpp
+++ b/dedup/include/chunking/ae_chunking.hpp
@@ -39,7 +39,7 @@ class AE_Chunking : public virtual Chunking_Technique {
      * @param file:  pointer to the file
      * @return size of the file
      */
-    uint64_t get_file_size(std::ifstream& file);
+    uint64_t get_file_size(std::istream& file);
 
     /**
      * @brief compares a new value with the current extreme and returns whether
@@ -84,6 +84,7 @@ class AE_Chunking : public virtual Chunking_Technique {
         @return: Vector containing fixed size chunks from file
     */
     std::vector<File_Chunk> chunk_file(std::string file_path) override;
+    void chunk_stream(std::vector<File_Chunk>& result, std::istream& stream) override;
 };
 
 #endif

--- a/dedup/include/chunking/chunking_common.hpp
+++ b/dedup/include/chunking/chunking_common.hpp
@@ -14,6 +14,8 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <sstream>
+#include <istream>
 #include "hash.hpp"
 #include "config.hpp"
 
@@ -98,14 +100,33 @@ class Chunking_Technique{
 
     public:
         std::string technique_name;
-        virtual std::vector<File_Chunk> chunk_file(std::string file_path) = 0;
+
         /**
          * @brief Chunk a file using a chunking technique and return the struct File_Chunks from this operation
+         * 
          * @param file_path: String containing path to file
          * @return: Vector of struct File_Chunk
          */
+        virtual std::vector<File_Chunk> chunk_file(std::string file_path) = 0;
+
+        /**
+         * @brief Chunk a stream using a chunking technique and append the struct File_Chunks from this operation
+         * to the vector passed in
+         * 
+         * @param stream: input stream containing the data to be chunked
+         * @return: void
+         */
+        virtual void chunk_stream(std::vector<File_Chunk>& result, std::istream& stream) = 0;
 
         virtual ~Chunking_Technique() {};
+
+        /**
+         * @brief Read every file in the directory and subdirectories into a buffer for each file and return it
+         * 
+         * @param dir_path : String containing path to the directory. Must be a valid directory path
+         * @return std::vector<std::istringstream> 
+         */
+        static std::vector<std::istringstream> read_files_to_buffers(std::string dir_path);
 };
 
 #endif

--- a/dedup/include/chunking/fixed_chunking.hpp
+++ b/dedup/include/chunking/fixed_chunking.hpp
@@ -3,6 +3,7 @@
 
 #include "chunking_common.hpp"
 #include "config.hpp"
+#include <istream>
 
 #define DEFAULT_FIXED_CHUNK_SIZE 4096
 
@@ -17,7 +18,7 @@ class Fixed_Chunking: public virtual Chunking_Technique{
 
     public:
 
-        Fixed_Chunking(){
+        Fixed_Chunking() {
             /**
              * @brief Default constructor. Initializes fixed_chunk_size to DEFAULT_CHUNK_SIZE
              * @return: void
@@ -42,6 +43,7 @@ class Fixed_Chunking: public virtual Chunking_Technique{
 
         // Implementation of chunk_file from Chunking_Technique
         std::vector<File_Chunk> chunk_file(std::string file_path) override;
+        void chunk_stream(std::vector<File_Chunk>& result, std::istream& stream) override;
 };
 
 #endif

--- a/dedup/include/chunking/gear_chunking.hpp
+++ b/dedup/include/chunking/gear_chunking.hpp
@@ -143,7 +143,8 @@ class Gear_Chunking : public virtual Chunking_Technique {
      * @param data Data stream to chunk.
      * @return A vector of File_Chuncks
      */
-    std::vector<File_Chunk> chunk_file(std::string file_path);
+    std::vector<File_Chunk> chunk_file(std::string file_path) override;
+    void chunk_stream(std::vector<File_Chunk>& result, std::istream& stream) override;
 };
 
 #endif

--- a/dedup/include/chunking/rabins_chunking.hpp
+++ b/dedup/include/chunking/rabins_chunking.hpp
@@ -89,7 +89,8 @@ class Rabins_Chunking : public virtual Chunking_Technique {
      * @param file_path the path of the file to be chunked
      * @return A vector of chunks
      */
-    std::vector<File_Chunk> chunk_file(std::string file_path);
+    std::vector<File_Chunk> chunk_file(std::string file_path) override;
+    void chunk_stream(std::vector<File_Chunk>& result, std::istream& stream) override;
 };
 
 #endif

--- a/dedup/src/chunking/ae_chunking.cpp
+++ b/dedup/src/chunking/ae_chunking.cpp
@@ -74,7 +74,7 @@ bool AE_Chunking::read_file(std::string file_path, std::ifstream& file) {
     }
 }
 
-uint64_t AE_Chunking::get_file_size(std::ifstream& file) {
+uint64_t AE_Chunking::get_file_size(std::istream& file) {
     file.seekg(0, std::ios_base::end);
     uint64_t file_size_bytes = file.tellg();
     // Seek back to beginning and set up bytes_to_read
@@ -130,4 +130,50 @@ std::vector<File_Chunk> AE_Chunking::chunk_file(std::string file_path) {
         }
     }
     return file_chunks;
+}
+
+void AE_Chunking::chunk_stream(std::vector<File_Chunk>& result, std::istream& stream) {
+    uint64_t read_buff_end = 0;
+
+    uint64_t file_size_bytes = get_file_size(stream);
+    uint64_t bytes_to_read =
+        std::min((uint64_t)BUFFER_SIZE, file_size_bytes);
+    uint64_t curr_bytes_read = 0;
+    while (curr_bytes_read < file_size_bytes) {
+        stream.read(&read_buffer[read_buff_end], bytes_to_read);
+        // mark the end of logical buffer
+        read_buff_end += stream.gcount() - 1;
+        // find cutpoint
+        uint32_t cutpoint = find_cutpoint(read_buffer, read_buff_end);
+        // create new chunk and push it to the vector
+        uint32_t chunk_size = cutpoint + 1;
+        File_Chunk new_chunk{chunk_size};
+        memccpy(new_chunk.get_data(), read_buffer, 0, chunk_size);
+        result.push_back(new_chunk);
+
+        /* there's a partial block at the end
+            * of the buffer; move it to the beginning of the buffer
+            * so we can append more from input stream
+            */
+        memmove(read_buffer, &read_buffer[cutpoint + 1],
+                read_buff_end - cutpoint);
+        curr_bytes_read += stream.gcount();
+        read_buff_end -= cutpoint;
+        // Handles the last chunk being smaller than buffer size
+        bytes_to_read = std::min(BUFFER_SIZE - read_buff_end,
+                                    file_size_bytes - curr_bytes_read);
+    }
+    // file fully loaded into the buffer
+    // chunk the rest of the buffer
+    int pos = 0;
+    while ((int)read_buff_end > pos) {
+        uint32_t cutpoint =
+            find_cutpoint(&read_buffer[pos], read_buff_end - pos);
+        uint32_t chunk_size = cutpoint + 1;
+        File_Chunk new_chunk{chunk_size};
+        memccpy(new_chunk.get_data(), &read_buffer[pos], 0, chunk_size);
+        result.push_back(new_chunk);
+        pos += chunk_size;
+    }
+    return;
 }

--- a/dedup/src/chunking/chunking_common.cpp
+++ b/dedup/src/chunking/chunking_common.cpp
@@ -13,6 +13,8 @@
 #include <cstring>
 #include <iostream>
 #include <string>
+#include <fstream>
+#include <filesystem>
 
 
 File_Chunk::File_Chunk(uint64_t _chunk_size) {
@@ -62,5 +64,39 @@ void File_Chunk::print() const {
     if (chunk_hash) {
         std::cout << "\tChunk Hash: " << chunk_hash->toString() << std::endl;
     }
-    std::cout << "\tChunk Data: " << chunk_data << std::endl;
+    std::cout << "\tChunk Data: ";
+    for (uint64_t i = 0; i < chunk_size; ++i) {
+        // this only works if the data is ASCII
+        std::cout << chunk_data[i];
+    }
+    std::cout << std::endl;
+}
+
+// ========== Chunking_Techniques =============
+std::vector<std::istringstream> Chunking_Technique::read_files_to_buffers(std::string dir_path) {
+    std::vector<std::istringstream> buffers;
+    for (const auto& entry : std::filesystem::recursive_directory_iterator(dir_path)) {
+        std::filesystem::path file_path = entry.path();
+        if (std::filesystem::is_directory(file_path)) {
+            continue;
+        }
+
+        std::ifstream file_ptr;
+        file_ptr.open(file_path, std::ios::in);
+        // get length of file:
+        file_ptr.seekg (0, std::ios::end);
+        long length = file_ptr.tellg();
+        file_ptr.seekg (0, std::ios::beg);
+        // allocate memory:
+        char *buffer = new char[length + 1];
+        // read data from file into the buffer
+        file_ptr.read(buffer, length);
+        buffer[length] = '\0';
+        // create string stream from the buffer (string will create a copy of the buffer)
+        buffers.emplace_back(std::string{buffer});
+        // cleanup
+        delete[] buffer;
+        file_ptr.close();
+    }
+    return buffers;
 }

--- a/dedup/src/chunking/fixed_chunking.cpp
+++ b/dedup/src/chunking/fixed_chunking.cpp
@@ -33,7 +33,7 @@ uint64_t Fixed_Chunking:: get_fixed_chunk_size(){
     return Fixed_Chunking::fixed_chunk_size;
 }
 
-std::vector<File_Chunk> Fixed_Chunking::chunk_file(std::string file_path){
+std::vector<File_Chunk> Fixed_Chunking::chunk_file(std::string file_path) {
     /**
         @brief Divides a file into fixed size chunks and returns a vector with these chunks
         @param file_path: Path to input file
@@ -77,4 +77,36 @@ std::vector<File_Chunk> Fixed_Chunking::chunk_file(std::string file_path){
     }
 
     return file_chunks;
+}
+
+void Fixed_Chunking::chunk_stream(std::vector<File_Chunk>& result, std::istream& stream) {
+    // Get chunk size from object
+    uint64_t chunk_size = get_fixed_chunk_size();
+
+    // Get size of file
+    stream.seekg(0,std::ios_base::end);
+    uint64_t file_size_bytes = stream.tellg();
+
+    // Seek back to beginning and set up bytes_to_read
+    stream.seekg(0,std::ios_base::beg);
+    uint32_t bytes_to_read = std::min(chunk_size, file_size_bytes);
+    
+
+    uint32_t curr_bytes_read = 0;
+    while(curr_bytes_read < file_size_bytes){
+        // Create buffer to store chunks
+        File_Chunk new_chunk{bytes_to_read};
+        
+        stream.read(new_chunk.get_data(), bytes_to_read);
+        
+        // Create new chunk and push it into vector
+        result.push_back(new_chunk);
+
+        curr_bytes_read += bytes_to_read;
+
+        // Handles the last chunk being smaller than @param chunk_size
+        bytes_to_read = std::min(chunk_size, file_size_bytes - curr_bytes_read);
+    }
+
+    return;
 }

--- a/dedup/src/chunking/gear_chunking.cpp
+++ b/dedup/src/chunking/gear_chunking.cpp
@@ -118,3 +118,49 @@ std::vector<File_Chunk> Gear_Chunking::chunk_file(std::string file_path) {
 
     return file_chunks;
 }
+
+void Gear_Chunking::chunk_stream(std::vector<File_Chunk>& result, std::istream& stream) {
+    return;
+
+    // std::vector<unsigned char> remain;
+    // std::vector<unsigned char> buffer(max_block_size);
+
+    // std::ifstream file_ptr(file_path, std::ios::binary);
+
+    // while (true) {
+    //     file_ptr.read((char*)buffer.data(), max_block_size);
+    //     uint64_t read_bytes = file_ptr.gcount();
+
+    //     if (read_bytes == 0) {
+    //         break;
+    //     }
+
+    //     // prepend remaining data from previous iteration before chopping.
+    //     buffer.insert(buffer.begin(), remain.begin(), remain.end());
+
+    //     // read data can be lower than actual buffer size.
+
+    //     uint64_t bf_end = read_bytes + remain.size();
+
+    //     std::vector<File_Chunk> chunks = chop(std::vector<unsigned char>(
+    //         buffer.begin(), buffer.begin() + bf_end));
+
+    //     File_Chunk last = chunks.back();
+    //     remain = std::vector<unsigned char>(last.get_data(),
+    //                                         last.get_data() + last.get_size());
+    //     chunks.pop_back();
+    //     for (uint32_t i = 0; i < chunks.size(); i++) {
+    //         file_chunks.push_back(chunks[i]);
+    //     }
+    //     buffer.resize(max_block_size);
+    // }
+
+    // if (remain.size() > 0) {
+    //     std::vector<File_Chunk> chunks = chop(remain);
+    //     for (uint32_t i = 0; i < chunks.size(); i++) {
+    //         file_chunks.push_back(chunks[i]);
+    //     }
+    // }
+
+    // return file_chunks;
+}

--- a/dedup/src/chunking/rabins_chunking.cpp
+++ b/dedup/src/chunking/rabins_chunking.cpp
@@ -180,3 +180,31 @@ std::vector<File_Chunk> Rabins_Chunking::chunk_file(std::string file_path) {
 
     return file_chunks;
 }
+
+void Rabins_Chunking::chunk_stream(std::vector<File_Chunk>& result, std::istream& stream) {
+    return;
+
+    // FILE *stream = fopen(file_path.c_str(), "rb");
+    // if (!stream) {
+    //     error = errno;
+    // }
+    // // prepare the stream for the new file
+    // reset_stream();
+    // // reset the hash function
+    // r_hash->init(window_size);
+
+    // while (true) {
+    //     int rc = rp_block_next();
+    //     if (rc == 0) {
+    //         File_Chunk new_chunk(block_size);
+    //         memccpy(new_chunk.get_data(), block_addr, 0, block_size);
+    //         file_chunks.push_back(new_chunk);
+    //     }
+    //     if (rc) {
+    //         assert(rc == EOF);
+    //         break;
+    //     }
+    // }
+
+    // return file_chunks;
+}

--- a/dedup/src/driver.cpp
+++ b/dedup/src/driver.cpp
@@ -20,14 +20,14 @@
 #include "ae_chunking.hpp"
 #include "gear_chunking.hpp"
 
-
-
 #include <ios>
 #include <fstream>
 #include <memory>
 #include <vector>
 #include <tuple>
 #include <filesystem>
+#include <sstream>
+#include <chrono>
 
 
 static void driver_function(
@@ -76,6 +76,7 @@ static void driver_function(
 
         for (const File_Chunk& fc : file_chunks){
             out_file << fc.to_string() << std::endl;
+            // fc.print();
         }
     }
 
@@ -83,12 +84,71 @@ static void driver_function(
     std::cout << "Total number of chunks: " << chunk_count << std::endl;
 }
 
+static void driver_function_stream(
+                                   const std::filesystem::path& dir_path, Chunking_Technique *chunk_method,
+                                   std::unique_ptr<Hashing_Technique>& hash_method, const std::string& output_file) {
+    /**
+     * @brief Uses the specified chunking technique to chunk the file, hash it using the specified hashing technique 
+     *        and print the hashes
+     * @todo: Change this to iterate over all files in directory
+     * @todo: Change the function to write hashes to file. Supporting function already exists in hashing_common.cpp
+     * 
+     * @param chunk_method: Chunking Technique Object. Object from a class inheriting the Chunking_Technique interface.
+     * @param hash_method: Hash Technique Object. Object from a class inheriting the Hashing_Technique interface.
+     * @return: void
+     * 
+     */
+    const std::string delimiter = ", ";
+    std::vector<File_Chunk> file_chunks;
+    
+    if (!std::filesystem::is_directory(dir_path)) {
+        std::cerr << dir_path << " is not a directory" << std::endl;
+        return;
+    }
 
-int main(int argc, char * argv[]){
-/**
- * @brief Main entry point for dedup.exe. Parses arguments and calls driver_function()
- * @todo: Add Config class which takes in parameters
- */
+    // open the output file for writing the hashes to
+    std::ofstream out_file(output_file, std::ios::out | std::ios::trunc);
+    if (!out_file.is_open()) {
+        std::cerr << "Failed to open " << output_file << " for writing" << std::endl;
+        return;
+    }
+
+    std::cout << "Begin reading files into memory..." << std::endl;
+    std::vector<std::istringstream> buffers = Chunking_Technique::read_files_to_buffers(dir_path);
+    std::cout << "Done!" << std::endl;
+    // Start timer
+    auto begin = std::chrono::high_resolution_clock::now();
+    for (std::istringstream& iss : buffers) {
+        // Note that chunk_stream takes in a stream reference so the stream may become invalid to use afterward
+        chunk_method->chunk_stream(file_chunks, iss);
+    }
+    // End timer
+    auto end = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> time_span = std::chrono::duration_cast<std::chrono::duration<double>>(end - begin);
+
+    // Hash chunks using specified Hashing_Technique
+    hash_method->hash_chunks(file_chunks);
+    // Write the hashes to the output file
+    uint64_t total_bytes = 0;
+    for (const File_Chunk& fc : file_chunks){
+        total_bytes += fc.get_size();
+        out_file << fc.to_string() << std::endl;
+        //fc.print();
+    }
+    out_file.close();
+
+    // Print stats
+    std::cout << "Total number of chunks: " << file_chunks.size() << std::endl;
+    std::cout << "Total bytes chunked: " << total_bytes << std::endl;
+    std::cout << "Chunking Throughput (MB/sec): " << (double)total_bytes / 1000000 / time_span.count() << std::endl;
+}
+
+
+int main(int argc, char * argv[]) {
+    /**
+     * @brief Main entry point for dedup.exe. Parses arguments and calls driver_function()
+     * @todo: Add Config class which takes in parameters
+     */ 
     if(argc != 3){
         std::cout << "Usage: ./dedup.exe <file_path> <config_file_path>" << std::endl;
         std::cout << "\t  <file_path>: Path to file to run chunking and hashing on." << std::endl;
@@ -148,7 +208,8 @@ int main(int argc, char * argv[]){
         }
 
         // Call driver function
-        driver_function(dir_path, chunk_method, hash_method, output_file);
+        // driver_function(dir_path, chunk_method, hash_method, output_file);
+        driver_function_stream(dir_path, chunk_method, hash_method, output_file);
 
         // Cleanup pointers
         delete chunk_method;


### PR DESCRIPTION
First draft of the factoring work to separate out the reading logic and chunking logic. I decided to read the entire file into a stringstream so minimum changes is needed to the current chunking logic. Eventually we probably want to properly implement a chunking interface that chunks a raw buffer instead.

Currently I've only implemented the new interface in AE and fixed. If there are no concern regarding this method then I will implement the new interface for Gear and Rabin chunking as well.